### PR TITLE
installation: invenio-celery dependency removal

### DIFF
--- a/invenio_ext/es.py
+++ b/invenio_ext/es.py
@@ -24,8 +24,6 @@ from __future__ import absolute_import
 from elasticsearch import Elasticsearch
 from elasticsearch.connection import RequestsHttpConnection
 
-from invenio_celery import celery
-
 es = None
 
 SEARCH_RECORD_MAPPING = {

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -25,7 +25,6 @@
 -e git+git://github.com/inveniosoftware/invenio-access.git#egg=invenio-access
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
--e git+git://github.com/inveniosoftware/invenio-celery.git#egg=invenio-celery
 -e git+git://github.com/inveniosoftware/invenio-collections.git#egg=invenio-collections
 -e git+git://github.com/inveniosoftware/invenio-knowledge.git#egg=invenio-knowledge
 -e git+git://github.com/inveniosoftware/invenio-oauth2server.git#egg=invenio-oauth2server

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ requirements = [
     'fixture>=1.5',
     'intbitset>=2.0.0',
     'invenio-base>=0.3.1',
-    'invenio-celery>=0.1.1',
     'invenio-utils>=0.2.0',
     'lxml>=3.3',
     # FIXME new oauthlib release after 0.7.2 has some compatible problems with


### PR DESCRIPTION
* Removes dependency to invenio-celery as it is no longer in use
  anywhere.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>