### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,4 +26,4 @@ Authors
 
 Invenio module that provides integration with Flask extensions.
 
-- CERN <info@invenio-software.org>
+- CERN <info@inveniosoftware.org>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Ext.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-ext
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_ext/passlib/__init__.py
+++ b/invenio_ext/passlib/__init__.py
@@ -39,12 +39,12 @@ Invenio legacy support:
    hash = password_context.encrypt(
        "mypassword",
        scheme="invenio_aes_encrypted_email",
-       user="info@invenio-software.org",
+       user="info@inveniosoftware.org",
     )
    password_context.verify(
        "mypassword", hash
        scheme="invenio_aes_encrypted_email",
-       user="info@invenio-software.org",
+       user="info@inveniosoftware.org",
    )
    password_context.needs_update(hash)
 

--- a/invenio_ext/script/__init__.py
+++ b/invenio_ext/script/__init__.py
@@ -146,7 +146,7 @@ def check_for_software_updates(flash_message=False):
                 flash(_('A newer version of Invenio is available for '
                         'download. You may want to visit '
                         '<a href="%(wiki)s">%()s</a>',
-                        wiki='<a href=\"http://invenio-software.org/wiki/'
+                        wiki='<a href=\"http://inveniosoftware.org/wiki/'
                              '/Installation/Download'), 'warning(html_safe)')
 
             return False

--- a/invenio_ext/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_ext/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-ext 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-17 10:15+0200\n"
 "PO-Revision-Date: 2015-09-17 10:15+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_ext/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_ext/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-ext 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-17 10:15+0200\n"
 "PO-Revision-Date: 2015-09-17 10:15+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_ext/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_ext/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-ext 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-17 10:15+0200\n"
 "PO-Revision-Date: 2015-09-17 10:15+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_ext/translations/invenio.pot
+++ b/invenio_ext/translations/invenio.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-ext 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-17 10:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_ext/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_ext/translations/it/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-ext 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-17 10:15+0200\n"
 "PO-Revision-Date: 2015-09-17 10:15+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ directory = invenio_ext/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_ext/translations/invenio.pot
 

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ setup(
     keywords='invenio TODO',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-ext',
     packages=[
         'invenio_ext',

--- a/tests/test_ext_passlib.py
+++ b/tests/test_ext_passlib.py
@@ -92,11 +92,11 @@ class PasslibTestCase(InvenioTestCase):
         hashval = ctx.encrypt(
             "mypassword",
             scheme="invenio_aes_encrypted_email",
-            user="info@invenio-software.org",
+            user="info@inveniosoftware.org",
         )
         assert ctx.verify("mypassword", hashval,
                           scheme="invenio_aes_encrypted_email",
-                          user="info@invenio-software.org", )
+                          user="info@inveniosoftware.org", )
         assert ctx.needs_update(hashval)
 
     def test_unicode_regression(self):
@@ -105,9 +105,9 @@ class PasslibTestCase(InvenioTestCase):
         hashval = ctx.encrypt(
             u"mypassword",
             scheme="invenio_aes_encrypted_email",
-            user=u"info@invenio-software.org",
+            user=u"info@inveniosoftware.org",
         )
         assert ctx.verify(u"mypassword", hashval,
                           scheme="invenio_aes_encrypted_email",
-                          user=u"info@invenio-software.org", )
+                          user=u"info@inveniosoftware.org", )
         assert ctx.needs_update(hashval)

--- a/tests/test_ext_restful.py
+++ b/tests/test_ext_restful.py
@@ -94,7 +94,7 @@ class DecoratorsTestCase(InvenioTestCase):
 
         # Create a user
         self.user = User(
-            email='info@invenio-software.org', nickname='tester'
+            email='info@inveniosoftware.org', nickname='tester'
         )
         self.user.password = "tester"
         db.session.add(self.user)
@@ -231,7 +231,7 @@ class RestfulPaginationTestCase(InvenioTestCase):
 
         # Create a user
         self.user = User(
-            email='info@invenio-software.org', nickname='tester'
+            email='info@inveniosoftware.org', nickname='tester'
         )
         self.user.password = "tester"
         db.session.add(self.user)
@@ -498,7 +498,7 @@ class RestfulSQLAlchemyPaginationTestCase(InvenioTestCase):
 
         # Create a user
         self.user = User(
-            email='info@invenio-software.org', nickname='tester'
+            email='info@inveniosoftware.org', nickname='tester'
         )
         self.user.password = "tester"
         db.session.add(self.user)


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>